### PR TITLE
feat: add Carousel of Memories invitation experience

### DIFF
--- a/config/invitation.ts
+++ b/config/invitation.ts
@@ -27,6 +27,22 @@ export const invitationCatalog: InvitationCatalog = {
   },
   presets: [
     {
+      slug: "carousel-of-memories",
+      title: "Carousel of Memories",
+      couple: "Luna & Arga",
+      theme: "Cinematic Memory Gallery",
+      palette: {
+        primary: "#d4a373",
+        secondary: "#f6c89f",
+        accent: "#ede0d4",
+      },
+      excerpt:
+        "An intimate 3D gallery where every scroll rotates a carousel of Luna & Arga's treasured memories.",
+      eventDate: "2025-11-22T18:30:00+07:00",
+      venue: "The Atrium Lumière, Jakarta",
+      timezone: "Asia/Jakarta",
+    },
+    {
       slug: "the-journey-of-us",
       title: "The Journey of Us",
       couple: "Ayla & Rendra",

--- a/src/app/invitation/carousel-of-memories/components/AdventuresCarouselSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/AdventuresCarouselSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PageSection } from "@components/shared/PageSection";
+
+const adventureMoments = [
+  {
+    title: "Montage Mode",
+    detail: "Video snippets glide across a reflective floor while ambient mountain hues wash over the gallery.",
+  },
+  {
+    title: "Sound Layers",
+    detail: "Birdsong, distant traffic, and laughter fade in and out as each panel reaches the spotlight.",
+  },
+  {
+    title: "Depth & Zoom",
+    detail: "Scroll-triggered camera pushes add cinematic depth so the carousel feels almost touchable.",
+  },
+];
+
+export function AdventuresCarouselSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 03"
+      title="Our Adventures Together"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#1b1f29] via-[#141923] to-[#0e111a] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(167,197,255,0.25),_transparent_70%)]" />
+      <p className="text-amber-100/80">
+        The carousel accelerates into montage mode — riverside picnics, mountain hikes, and city lights reflected beneath our
+        feet. Each rotation gently shifts the lighting from sunrise gold to twilight blue, mirroring the adventures we shared.
+      </p>
+      <div className="grid gap-6 lg:grid-cols-2 lg:items-center">
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{ duration: 0.7 }}
+          className="relative overflow-hidden rounded-[2.5rem] border border-amber-100/20 bg-slate-950/40"
+        >
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,197,255,0.18),_transparent_80%)]" />
+          <div className="relative h-72">
+            <div className="absolute inset-8 rounded-3xl border border-amber-100/20 bg-gradient-to-br from-slate-900/80 via-slate-950/60 to-slate-900/90" />
+            <motion.div
+              className="absolute inset-x-16 bottom-10 h-28 rounded-full bg-gradient-to-r from-amber-200/10 via-amber-100/5 to-amber-200/10 blur-2xl"
+              animate={{ opacity: [0.2, 0.5, 0.2], scale: [0.95, 1.05, 0.95] }}
+              transition={{ repeat: Infinity, duration: 6 }}
+            />
+            <motion.div
+              className="absolute inset-x-20 top-10 h-40 rounded-3xl border border-amber-100/30 bg-gradient-to-br from-slate-800/80 via-slate-900/60 to-slate-950/80"
+              animate={{ rotate: [0, 4, -4, 0] }}
+              transition={{ repeat: Infinity, duration: 12, ease: "easeInOut" }}
+            />
+          </div>
+        </motion.div>
+        <ul className="space-y-4 text-sm text-amber-100/80">
+          {adventureMoments.map((moment) => (
+            <li key={moment.title} className="rounded-2xl border border-amber-100/20 bg-slate-950/40 p-4 shadow-inner">
+              <h3 className="font-display text-xl text-amber-100">{moment.title}</h3>
+              <p className="mt-2 text-amber-100/70">{moment.detail}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/CarouselMemoriesHero.tsx
+++ b/src/app/invitation/carousel-of-memories/components/CarouselMemoriesHero.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const frameVariants = {
+  initial: { opacity: 0, y: 24, rotateX: -12 },
+  animate: { opacity: 1, y: 0, rotateX: 0 },
+};
+
+const memoryFrames = [
+  {
+    id: "frame-1",
+    label: "First hello",
+    accent: "from-amber-200/60 via-amber-100/30 to-transparent",
+    delay: 0.25,
+  },
+  {
+    id: "frame-2",
+    label: "Late night drives",
+    accent: "from-rose-200/40 via-rose-100/20 to-transparent",
+    delay: 0.4,
+  },
+  {
+    id: "frame-3",
+    label: "Proposal glow",
+    accent: "from-yellow-200/40 via-amber-100/20 to-transparent",
+    delay: 0.55,
+  },
+];
+
+export function CarouselMemoriesHero() {
+  return (
+    <div className="relative mx-auto max-w-5xl overflow-hidden rounded-[3rem] border border-amber-100/60 bg-gradient-to-b from-slate-950/80 via-slate-900/70 to-slate-900 px-12 pb-20 pt-24 text-slate-100 shadow-[0_40px_120px_-60px_rgba(12,10,9,0.8)]">
+      <div className="absolute inset-x-0 -top-32 h-64 bg-[radial-gradient(circle_at_center,_rgba(255,228,196,0.28),_transparent_65%)] blur-3xl" />
+      <div className="relative grid gap-12 lg:grid-cols-[1.3fr_1fr] lg:items-center">
+        <div className="space-y-6 text-left">
+          <motion.p
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="text-sm uppercase tracking-[0.3em] text-amber-200/80"
+          >
+            Enter the memory hall
+          </motion.p>
+          <motion.h1
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.2 }}
+            className="font-display text-4xl leading-tight text-amber-100 sm:text-5xl"
+          >
+            Welcome to Luna &amp; Arga&apos;s cinematic carousel of memories.
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.35 }}
+            className="max-w-xl text-lg text-amber-50/80"
+          >
+            Glide through the spotlighted frames, let the warm lighting guide your scroll, and relive the chapters that brought
+            us to this wedding celebration.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.5 }}
+            className="flex flex-wrap items-center gap-4 text-sm text-amber-100/80"
+          >
+            <div className="rounded-full border border-amber-300/40 bg-slate-950/60 px-4 py-2 backdrop-blur">
+              Cinematic Memory Gallery
+            </div>
+            <div className="flex items-center gap-2 rounded-full border border-amber-200/30 bg-slate-950/60 px-4 py-2 backdrop-blur">
+              <span className="h-2 w-2 rounded-full bg-amber-300 animate-pulse" />
+              Scroll to rotate the carousel
+            </div>
+          </motion.div>
+        </div>
+        <div className="relative mx-auto aspect-[3/4] w-full max-w-xs overflow-hidden rounded-[2.5rem] border border-amber-200/40 bg-gradient-to-b from-slate-900 via-slate-950 to-black shadow-[0_20px_60px_-40px_rgba(0,0,0,0.8)]">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,214,165,0.45),_transparent_70%)]" />
+          <div className="absolute inset-6 rounded-[2rem] border border-amber-100/20 bg-slate-950/70 backdrop-blur">
+            <div className="absolute inset-x-8 top-6 flex flex-col items-center gap-6">
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ duration: 0.8, delay: 0.45, ease: [0.33, 1, 0.68, 1] }}
+                className="h-16 w-16 rounded-full border border-amber-200/30 bg-gradient-to-br from-amber-200/50 via-amber-100/20 to-transparent shadow-inner"
+              />
+              <motion.div
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.55 }}
+                className="h-40 w-full rounded-2xl border border-amber-100/10 bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950"
+              />
+            </div>
+            <div className="absolute inset-x-10 bottom-10 flex flex-col items-center gap-3 text-center text-xs uppercase tracking-[0.3em] text-amber-100/70">
+              <span className="text-[0.65rem]">Interactive Scroll</span>
+              <span className="text-[0.65rem]">Cinematic Lighting</span>
+            </div>
+          </div>
+          {memoryFrames.map((frame) => (
+            <motion.div
+              key={frame.id}
+              variants={frameVariants}
+              initial="initial"
+              animate="animate"
+              transition={{ duration: 0.7, delay: frame.delay, ease: [0.33, 1, 0.68, 1] }}
+              className="absolute left-1/2 top-1/2 h-28 w-24 -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-amber-100/40 bg-slate-900/70 backdrop-blur"
+              style={{ transform: "translate(-50%, -50%) rotateX(12deg)", boxShadow: "0 25px 60px -35px rgba(0,0,0,0.6)" }}
+            >
+              <div className={`absolute inset-0 rounded-2xl bg-gradient-to-b ${frame.accent}`} />
+              <div className="absolute inset-2 rounded-[1.2rem] border border-amber-100/30 bg-slate-950/80" />
+              <p className="absolute inset-x-3 bottom-3 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-amber-100/70 text-center">
+                {frame.label}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.7 }}
+        className="mt-20 flex items-center justify-center gap-3 text-sm text-amber-100/70"
+      >
+        <motion.span
+          animate={{ y: [0, 8, 0] }}
+          transition={{ repeat: Infinity, duration: 2, ease: "easeInOut" }}
+          className="text-lg"
+        >
+          ↓
+        </motion.span>
+        Scroll slowly to enter the gallery
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/ClosingSceneSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/ClosingSceneSection.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PageSection } from "@components/shared/PageSection";
+
+const gratitudeNotes = [
+  "Thank you for stepping into our memory hall.",
+  "Your presence turns every frame into something brighter.",
+  "We cannot wait to celebrate the next chapter with you.",
+];
+
+export function ClosingSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 06"
+      title="Closing Scene & Gratitude"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#090b12] via-[#07060c] to-[#05040a] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(209,213,255,0.18),_transparent_80%)]" />
+      <div className="relative overflow-hidden rounded-[2rem] border border-amber-100/20 bg-slate-950/50 p-10 text-center">
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 0.4 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ duration: 1 }}
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(241,245,255,0.2),_transparent_80%)]"
+        />
+        <motion.div
+          className="relative mx-auto flex h-48 w-48 items-center justify-center rounded-full border border-amber-100/30 bg-slate-950/80"
+          animate={{ rotate: [0, 3, -3, 0] }}
+          transition={{ repeat: Infinity, duration: 14, ease: "easeInOut" }}
+        >
+          <span className="text-2xl">⭐</span>
+        </motion.div>
+        <div className="relative mt-8 space-y-4 text-amber-100/80">
+          {gratitudeNotes.map((note) => (
+            <p key={note} className="text-sm text-amber-100/80">
+              {note}
+            </p>
+          ))}
+        </div>
+        <button className="relative mt-10 inline-flex items-center justify-center rounded-full border border-amber-200/30 bg-gradient-to-r from-amber-200/30 via-amber-100/10 to-amber-200/30 px-6 py-3 text-sm font-medium text-amber-50 transition hover:from-amber-200/50 hover:to-amber-200/50">
+          Replay the Gallery
+        </button>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/FirstDaysCarouselSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/FirstDaysCarouselSection.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PageSection } from "@components/shared/PageSection";
+
+const memories = [
+  {
+    title: "Our First Messages",
+    description: "Glowing chat bubbles hover beside the carousel as the first panels rotate into view.",
+  },
+  {
+    title: "Favorite Corner Cafe",
+    description: "Warm ambient lighting deepens while gentle camera flashes mimic captured polaroids.",
+  },
+  {
+    title: "The First Laugh",
+    description: "Audio waveforms shimmer in sync with our laughter, softly animating above the frame.",
+  },
+];
+
+export function FirstDaysCarouselSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 02"
+      title="Carousel of Our First Days"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#271a16] via-[#1f1512] to-[#160f0c] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(253,230,138,0.2),_transparent_75%)]" />
+      <p className="text-amber-100/80">
+        Slow rotations reveal the sparks that started it all. Each scroll nudges the carousel by fifteen degrees, unveiling new
+        frames bathed in honeyed gold and soft vignette shadows.
+      </p>
+      <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+        <motion.div
+          initial={{ rotateY: -12, opacity: 0 }}
+          whileInView={{ rotateY: 0, opacity: 1 }}
+          viewport={{ once: true, amount: 0.4 }}
+          transition={{ duration: 0.7, ease: [0.25, 0.1, 0.25, 1] }}
+          className="relative h-72 rounded-[2.5rem] border border-amber-200/20 bg-slate-950/40"
+        >
+          <div className="absolute inset-0 rounded-[2.5rem] bg-[radial-gradient(circle_at_top,_rgba(255,222,173,0.2),_transparent_75%)]" />
+          <div className="absolute inset-10 grid grid-cols-3 gap-4">
+            {[0, 1, 2, 3, 4, 5].map((index) => (
+              <div
+                key={index}
+                className="rounded-2xl border border-amber-100/20 bg-gradient-to-b from-slate-900/80 via-slate-950/60 to-slate-950/90 shadow-[0_12px_30px_-20px_rgba(0,0,0,0.7)]"
+                style={{ transform: `rotateY(${index * 15 - 45}deg)` }}
+              >
+                <div className="flex h-full flex-col items-center justify-center gap-1 p-4 text-center text-[0.65rem] uppercase tracking-[0.3em] text-amber-100/80">
+                  <span className="text-lg">🖼️</span>
+                  Memory {index + 1}
+                </div>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+        <ul className="space-y-4 text-sm text-amber-100/80">
+          {memories.map((memory) => (
+            <li key={memory.title} className="rounded-2xl border border-amber-200/20 bg-slate-950/40 p-4 shadow-inner">
+              <h3 className="font-display text-xl text-amber-100">{memory.title}</h3>
+              <p className="mt-2 text-amber-100/70">{memory.description}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/InteractiveHighlightsSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/InteractiveHighlightsSection.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PageSection } from "@components/shared/PageSection";
+
+const features = [
+  {
+    title: "Scroll to Rotate",
+    description: "Subtle easing keeps every scroll-linked rotation smooth and cinematic, replicating a steady camera rig.",
+  },
+  {
+    title: "Hover Captions",
+    description: "Each frame whispers the story behind the memory with elegant type that glows on hover.",
+  },
+  {
+    title: "Auto-Play Montage",
+    description: "Idle visitors witness a gentle autoplay sequence accompanied by a softly looping score.",
+  },
+  {
+    title: "Guestbook Frames",
+    description: "Messages from loved ones appear as miniature frames orbiting the carousel after an RSVP is submitted.",
+  },
+];
+
+export function InteractiveHighlightsSection() {
+  return (
+    <PageSection
+      eyebrow="Interactive"
+      title="Immersive Touchpoints"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#15100d] via-[#110d0a] to-[#0d0907] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(244,196,134,0.22),_transparent_80%)]" />
+      <p className="text-amber-100/80">
+        Beyond the cinematic scroll, Carousel of Memories invites guests to linger and interact with the gallery. These touches
+        transform the site into an intimate experience that feels curated just for them.
+      </p>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {features.map((feature) => (
+          <motion.div
+            key={feature.title}
+            className="rounded-2xl border border-amber-100/20 bg-slate-950/50 p-5"
+            whileHover={{ y: -4, borderColor: "rgba(255, 214, 170, 0.6)" }}
+            transition={{ type: "spring", stiffness: 200, damping: 18 }}
+          >
+            <h3 className="font-display text-xl text-amber-100">{feature.title}</h3>
+            <p className="mt-2 text-sm text-amber-100/70">{feature.description}</p>
+          </motion.div>
+        ))}
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/InvitationRevealSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/InvitationRevealSection.tsx
@@ -1,0 +1,65 @@
+import { invitationCatalog } from "@config/invitation";
+import { PageSection } from "@components/shared/PageSection";
+import { formatDateRange } from "@lib/utils";
+
+const invitation = invitationCatalog.presets.find((preset) => preset.slug === "carousel-of-memories");
+
+export function InvitationRevealSection() {
+  if (!invitation) {
+    return null;
+  }
+
+  const startDate = new Date(invitation.eventDate);
+  const endDate = new Date(startDate.getTime() + 3 * 60 * 60 * 1000);
+  const eventWindow = formatDateRange(startDate, endDate);
+
+  return (
+    <PageSection
+      eyebrow="Scene 05"
+      title="The Wedding Invitation"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#20140f] via-[#1a110d] to-[#120b08] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(250,224,162,0.3),_transparent_75%)]" />
+      <div className="grid gap-6 lg:grid-cols-[1fr_1fr] lg:items-center">
+        <div className="space-y-4">
+          <p className="text-amber-100/80">
+            The carousel slows to stillness, dissolving into a single illuminated frame. All supporting memories fade into soft
+            silhouettes as the wedding details come into focus, inviting you to be part of our next chapter.
+          </p>
+          <ul className="space-y-2 text-sm text-amber-100/80">
+            <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3 text-amber-100/80">
+              <span className="text-lg">🕰️</span>
+              {eventWindow}
+            </li>
+            <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3 text-amber-100/80">
+              <span className="text-lg">📍</span>
+              {invitation.venue}
+            </li>
+            <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3 text-amber-100/80">
+              <span className="text-lg">🎧</span>
+              A brighter reprise of our soundtrack fades in as the RSVP panel appears.
+            </li>
+          </ul>
+        </div>
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-amber-100/30 bg-slate-950/50 p-6 text-center">
+          <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,240,217,0.35),_transparent_75%)]" />
+          <div className="space-y-2 font-display text-amber-100">
+            <p className="text-sm uppercase tracking-[0.3em] text-amber-200/70">Now a new story is about to begin</p>
+            <p className="text-3xl">{invitation.couple}</p>
+            <p className="text-sm uppercase tracking-[0.3em] text-amber-200/60">invite you to celebrate love</p>
+          </div>
+          <div className="mt-6 rounded-3xl border border-amber-100/20 bg-slate-950/60 p-6">
+            <p className="text-sm uppercase tracking-[0.4em] text-amber-200/70">Wedding Celebration</p>
+            <p className="mt-3 text-2xl font-semibold text-amber-100">
+              {startDate.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+            </p>
+            <p className="mt-4 text-sm text-amber-100/70">{invitation.venue}</p>
+            <button className="mt-6 inline-flex items-center justify-center rounded-full border border-amber-200/30 bg-gradient-to-r from-amber-200/40 via-amber-100/20 to-amber-200/40 px-6 py-3 text-sm font-medium text-amber-950 shadow-[0_12px_30px_-20px_rgba(0,0,0,0.8)] transition hover:from-amber-200/60 hover:to-amber-200/60">
+              RSVP &amp; Save the Date
+            </button>
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/MemoryHallOpeningSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/MemoryHallOpeningSection.tsx
@@ -1,0 +1,31 @@
+import { PageSection } from "@components/shared/PageSection";
+
+const openingHighlights = [
+  "Soft spotlight reveals a floating frame with our very first photo together.",
+  "Subtle piano score fades in as the vignette around the gallery lifts.",
+  "Scroll cues a cinematic push-in, inviting guests deeper into the memory hall.",
+];
+
+export function MemoryHallOpeningSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 01"
+      title="Welcome to Our Memory Hall"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-amber-50"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(244,214,169,0.35),_transparent_65%)] opacity-80" />
+      <p className="text-amber-100/80">
+        The gallery awakens with a single illuminated frame. Warm light spills across dark walls while a soft piano overture
+        prepares our guests for the story ahead. As you begin to scroll, the camera glides forward and the doors to our carousel
+        of memories quietly open.
+      </p>
+      <ul className="grid gap-3 text-sm text-amber-100/80 sm:grid-cols-3">
+        {openingHighlights.map((highlight) => (
+          <li key={highlight} className="rounded-2xl border border-amber-200/20 bg-slate-950/60 p-4 text-amber-100/80">
+            {highlight}
+          </li>
+        ))}
+      </ul>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/components/ProposalSpotlightSection.tsx
+++ b/src/app/invitation/carousel-of-memories/components/ProposalSpotlightSection.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PageSection } from "@components/shared/PageSection";
+
+const petals = [
+  { left: "10%", top: "12%", delay: 0 },
+  { left: "28%", top: "8%", delay: 0.2 },
+  { left: "46%", top: "18%", delay: 0.4 },
+  { left: "68%", top: "10%", delay: 0.6 },
+  { left: "82%", top: "22%", delay: 0.8 },
+  { left: "18%", top: "36%", delay: 1 },
+  { left: "34%", top: "48%", delay: 1.2 },
+  { left: "58%", top: "38%", delay: 1.4 },
+  { left: "74%", top: "46%", delay: 1.6 },
+  { left: "12%", top: "62%", delay: 1.8 },
+  { left: "32%", top: "70%", delay: 2 },
+  { left: "52%", top: "68%", delay: 2.2 },
+  { left: "70%", top: "72%", delay: 2.4 },
+  { left: "86%", top: "60%", delay: 2.6 },
+];
+
+export function ProposalSpotlightSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 04"
+      title="The Proposal Spotlight"
+      className="relative overflow-hidden border-amber-100/40 bg-gradient-to-br from-[#2a1b1b] via-[#1d1111] to-[#130a0a] text-amber-100"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_center,_rgba(255,196,196,0.25),_transparent_75%)]" />
+      <div className="relative overflow-hidden rounded-[2rem] border border-amber-100/30 bg-slate-950/50 p-8">
+        <motion.div
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 0.25 }}
+          viewport={{ once: true }}
+          transition={{ duration: 1.2 }}
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(255,216,190,0.45),_transparent_80%)]"
+        />
+        <div className="relative grid gap-10 lg:grid-cols-[1.1fr_1fr] lg:items-center">
+          <div className="relative h-72 overflow-hidden rounded-[1.5rem] border border-amber-100/30 bg-gradient-to-br from-slate-900/80 via-slate-950/70 to-slate-900/90">
+            {petals.map((petal, index) => (
+              <motion.span
+                key={index}
+                className="absolute text-xl opacity-70"
+                style={{ left: petal.left, top: petal.top }}
+                animate={{ y: [0, 20, 0], opacity: [0.3, 0.8, 0.3] }}
+                transition={{ duration: 6 + (index % 4), repeat: Infinity, ease: "easeInOut", delay: petal.delay }}
+              >
+                🌸
+              </motion.span>
+            ))}
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              whileInView={{ scale: 1, opacity: 1 }}
+              viewport={{ once: true, amount: 0.6 }}
+              transition={{ duration: 0.7 }}
+              className="absolute inset-10 rounded-[1.2rem] border border-amber-100/40 bg-slate-950/60 backdrop-blur"
+            >
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-amber-100/80">
+                <span className="text-3xl">💍</span>
+                <p className="text-sm uppercase tracking-[0.35em]">She said yes</p>
+              </div>
+            </motion.div>
+          </div>
+          <div className="space-y-4 text-amber-100/80">
+            <p className="text-amber-100/80">
+              Under a canopy of falling petals, Luna whispered yes as golden light gathered around us. The carousel paused, all
+              other frames softened into blur, and the soundtrack rose to hold that suspended second forever.
+            </p>
+            <ul className="space-y-2 text-sm">
+              <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3">
+                <span className="text-lg">✨</span>
+                Depth-of-field pushes every other memory into bokeh while the proposal glows at center stage.
+              </li>
+              <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3">
+                <span className="text-lg">🎼</span>
+                A gentle swell in the piano theme ushers in heartfelt narration of the question that changed everything.
+              </li>
+              <li className="flex items-center gap-3 rounded-xl border border-amber-100/20 bg-slate-950/40 p-3">
+                <span className="text-lg">🌹</span>
+                Floating particles drift upward, mirroring the joyful rush of that moment.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/gallery/page.tsx
+++ b/src/app/invitation/carousel-of-memories/gallery/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Carousel of Memories — Gallery",
+  description: "Placeholder gallery page for the Carousel of Memories invitation variant.",
+};
+
+export default function CarouselOfMemoriesGalleryPage() {
+  return (
+    <BaseInvitationLayout
+      theme="noir-gold"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-amber-100">
+          <h1 className="font-display text-5xl">Gallery</h1>
+          <p className="mt-3 text-amber-100/70">
+            Insert Carousel of Memories imagery, motion renders, or interactive prototypes here.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-amber-100/40 bg-slate-950/60 text-amber-100">
+        <p className="text-amber-100/80">
+          Replace this placeholder when the curated gallery assets and cinematic renders for Carousel of Memories are ready to
+          showcase.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/gift/page.tsx
+++ b/src/app/invitation/carousel-of-memories/gift/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Carousel of Memories — Gift",
+  description: "Placeholder gift registry page for the Carousel of Memories invitation variant.",
+};
+
+export default function CarouselOfMemoriesGiftPage() {
+  return (
+    <BaseInvitationLayout
+      theme="noir-gold"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-amber-100">
+          <h1 className="font-display text-5xl">Gifts &amp; Blessings</h1>
+          <p className="mt-3 text-amber-100/70">
+            Outline registry details or heartfelt notes for Carousel of Memories guests here.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-amber-100/40 bg-slate-950/60 text-amber-100">
+        <p className="text-amber-100/80">
+          Replace this placeholder with the preferred gift registry, banking details, or blessings instructions tailored to the
+          Carousel of Memories concept.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/page.tsx
+++ b/src/app/invitation/carousel-of-memories/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { invitationCatalog } from "@config/invitation";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { MemoryHallOpeningSection } from "./components/MemoryHallOpeningSection";
+import { CarouselMemoriesHero } from "./components/CarouselMemoriesHero";
+import { FirstDaysCarouselSection } from "./components/FirstDaysCarouselSection";
+import { AdventuresCarouselSection } from "./components/AdventuresCarouselSection";
+import { ProposalSpotlightSection } from "./components/ProposalSpotlightSection";
+import { InvitationRevealSection } from "./components/InvitationRevealSection";
+import { ClosingSceneSection } from "./components/ClosingSceneSection";
+import { InteractiveHighlightsSection } from "./components/InteractiveHighlightsSection";
+
+const invitation = invitationCatalog.presets.find((preset) => preset.slug === "carousel-of-memories");
+
+export const metadata: Metadata = {
+  title: "Carousel of Memories",
+  description: "A cinematic invitation experience where a 3D carousel reveals Luna & Arga's most intimate memories.",
+};
+
+export default function CarouselOfMemoriesPage() {
+  if (!invitation) {
+    notFound();
+  }
+
+  return (
+    <BaseInvitationLayout
+      theme="noir-gold"
+      hero={<CarouselMemoriesHero />}
+      footer={
+        <div className="space-y-2">
+          <p>Thank you for travelling through Luna &amp; Arga&apos;s Carousel of Memories.</p>
+          <p className="text-xs text-amber-200/70">Designed as an intimate cinematic gallery for cherished guests.</p>
+        </div>
+      }
+    >
+      <MemoryHallOpeningSection />
+      <FirstDaysCarouselSection />
+      <AdventuresCarouselSection />
+      <ProposalSpotlightSection />
+      <InvitationRevealSection />
+      <InteractiveHighlightsSection />
+      <ClosingSceneSection />
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/rsvp/page.tsx
+++ b/src/app/invitation/carousel-of-memories/rsvp/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Carousel of Memories — RSVP",
+  description: "Placeholder RSVP page for the Carousel of Memories invitation variant.",
+};
+
+export default function CarouselOfMemoriesRsvpPage() {
+  return (
+    <BaseInvitationLayout
+      theme="noir-gold"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-amber-100">
+          <h1 className="font-display text-5xl">RSVP</h1>
+          <p className="mt-3 text-amber-100/70">
+            Integrate the interactive RSVP experience and guestbook frames for Carousel of Memories here.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-amber-100/40 bg-slate-950/60 text-amber-100">
+        <p className="text-amber-100/80">
+          Replace this placeholder once the RSVP workflow, guestbook integration, and confirmation animations are implemented
+          for Carousel of Memories.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/carousel-of-memories/story/page.tsx
+++ b/src/app/invitation/carousel-of-memories/story/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Carousel of Memories — Story",
+  description: "Placeholder story page for the Carousel of Memories invitation variant.",
+};
+
+export default function CarouselOfMemoriesStoryPage() {
+  return (
+    <BaseInvitationLayout
+      theme="noir-gold"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-amber-100">
+          <h1 className="font-display text-5xl">Storyline</h1>
+          <p className="mt-3 text-amber-100/70">
+            Customize this scene with deeper narrative beats, voiceover scripts, and photo curation for Luna &amp; Arga.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-amber-100/40 bg-slate-950/60 text-amber-100">
+        <p className="text-amber-100/80">
+          Replace this placeholder once the cinematic storytelling script and assets for Carousel of Memories are ready to be
+          woven into the experience.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Carousel of Memories preset to the invitation catalog
- implement the Carousel of Memories landing page with cinematic hero, memory scenes, and invitation reveal sections
- scaffold supporting story, gallery, gift, and RSVP routes for the new invitation theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2735d562c8322995ba77bcf799371