### PR TITLE
feat: add Road to Forever invitation variant

### DIFF
--- a/config/invitation.ts
+++ b/config/invitation.ts
@@ -72,5 +72,21 @@ export const invitationCatalog: InvitationCatalog = {
       venue: "The Forest Chapel, Bandung",
       timezone: "Asia/Jakarta",
     },
+    {
+      slug: "road-to-forever",
+      title: "Road to Forever",
+      couple: "Nara & Dimas",
+      theme: "Sunset Road-Trip",
+      palette: {
+        primary: "#f97316",
+        secondary: "#38bdf8",
+        accent: "#fcd34d",
+      },
+      excerpt:
+        "A horizontal-scroll road journey that guides guests through milestones before arriving at Nara & Dimas' celebration.",
+      eventDate: "2025-07-12T16:00:00+07:00",
+      venue: "Serenity Garden Pavilion, Bandung",
+      timezone: "Asia/Jakarta",
+    },
   ],
 };

--- a/src/app/invitation/road-to-forever/components/AdventureSceneSection.tsx
+++ b/src/app/invitation/road-to-forever/components/AdventureSceneSection.tsx
@@ -1,0 +1,57 @@
+import { PageSection } from "@components/shared/PageSection";
+
+export function AdventureSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 3"
+      title="Miles of Adventures"
+      className="border-emerald-200/60 bg-gradient-to-br from-emerald-50 via-white to-sky-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1fr_1.1fr] lg:items-center">
+        <div className="space-y-4">
+          <p>
+            The drive ascends rolling hills and glistening lakes bathed in golden hour light. Road curvature is defined by an
+            SVG path that tilts the car gently as it climbs and descends, echoing the storyboard&apos;s kinetic energy.
+          </p>
+          <p>
+            Light shifts from orange to purple using layered gradients and blend modes. A subtle camera shake conveys the
+            excitement of the adventure while keeping the interface calm and readable.
+          </p>
+          <ul className="space-y-3 text-sm text-slate-600">
+            <li className="rounded-2xl border border-emerald-200/60 bg-white/80 p-4">
+              <span className="font-semibold text-emerald-600">MotionPathPlugin</span>
+              <p className="mt-1">Drive the car along an undulating path with scrubbed ScrollTrigger progress.</p>
+            </li>
+            <li className="rounded-2xl border border-purple-200/60 bg-white/80 p-4">
+              <span className="font-semibold text-purple-600">Dynamic lighting</span>
+              <p className="mt-1">Swap gradient overlays to transition from afternoon glow to dusk.</p>
+            </li>
+            <li className="rounded-2xl border border-sky-200/60 bg-white/80 p-4">
+              <span className="font-semibold text-sky-600">Cinematic touch</span>
+              <p className="mt-1">Add a low amplitude y-axis oscillation to mimic suspension bounce.</p>
+            </li>
+          </ul>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border border-emerald-100 bg-white/80 p-10 shadow-inner">
+          <div className="absolute inset-x-12 top-10 h-20 rounded-full bg-gradient-to-r from-emerald-200/50 via-sky-200/40 to-purple-200/50 blur-xl" />
+          <div className="relative h-36 overflow-hidden rounded-[2.5rem] border border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-purple-50">
+            <div className="absolute inset-x-6 bottom-8 h-3 rounded-full bg-gradient-to-r from-emerald-300 via-sky-300 to-purple-300 opacity-80" />
+            <div className="absolute inset-x-10 top-6 h-24 rounded-[2rem] border border-slate-200/70 bg-white/80">
+              <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(16,185,129,0.08),_rgba(59,130,246,0.12))]" />
+            </div>
+            <div className="absolute bottom-10 right-10 rounded-full border border-purple-300/60 bg-purple-100/80 px-4 py-2 text-xs uppercase tracking-[0.2em] text-purple-600 shadow">
+              Scenic route
+            </div>
+            <div className="absolute bottom-10 left-10 flex items-center gap-3 rounded-full border border-emerald-300/70 bg-emerald-100 px-4 py-2 text-emerald-700 shadow">
+              <span className="text-lg">🌄</span>
+              <span className="text-xs uppercase tracking-[0.2em]">Peaks &amp; Lakes</span>
+            </div>
+          </div>
+          <p className="mt-6 text-sm text-slate-500">
+            Layer optional particle sprites (mist, sparkles) with low opacity to emphasize altitude and breeze.
+          </p>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/DestinationSceneSection.tsx
+++ b/src/app/invitation/road-to-forever/components/DestinationSceneSection.tsx
@@ -1,0 +1,51 @@
+import { PageSection } from "@components/shared/PageSection";
+
+export function DestinationSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 5"
+      title="Wedding Destination Reveal"
+      className="border-amber-200/60 bg-gradient-to-br from-white via-amber-50 to-rose-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-4">
+          <p>
+            The road finally opens to a celebration-ready venue framed by arches of flowers. Details for the ceremony appear in
+            a staggered rhythm, reinforcing the ScrollTrigger finale.
+          </p>
+          <p>
+            Introduce RSVP and map buttons with a gentle bounce using Framer Motion. Confetti particles can be triggered when the
+            RSVP modal is submitted to echo the storyboard&apos;s celebratory finale.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-3xl border border-amber-200/70 bg-white/80 p-5 text-sm text-slate-600">
+              <p className="font-semibold text-amber-600">Content blocks</p>
+              <p className="mt-1">Event date, time, venue, RSVP call-to-action, and embedded map.</p>
+            </div>
+            <div className="rounded-3xl border border-rose-200/70 bg-white/80 p-5 text-sm text-slate-600">
+              <p className="font-semibold text-rose-600">Interaction map</p>
+              <p className="mt-1">Submitting RSVP triggers confetti and pauses the car to signify arrival.</p>
+            </div>
+          </div>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border border-amber-200 bg-white/80 p-8 shadow-inner">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(251,191,36,0.2),_transparent_75%)]" />
+          <div className="relative space-y-5">
+            <div className="rounded-[2.5rem] border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-rose-50 p-6 text-center text-slate-700 shadow">
+              <p className="text-sm uppercase tracking-[0.35em] text-amber-500">Welcome to our forever</p>
+              <p className="mt-2 font-display text-2xl text-slate-900">12 July 2025 · 16:00 WIB</p>
+              <p className="text-sm text-slate-600">Serenity Garden Pavilion, Bandung</p>
+              <div className="mt-5 flex flex-wrap items-center justify-center gap-3 text-sm">
+                <span className="rounded-full border border-amber-300/70 bg-amber-100 px-4 py-2 text-amber-700">RSVP Reveal</span>
+                <span className="rounded-full border border-rose-300/70 bg-rose-100 px-4 py-2 text-rose-700">Interactive Map</span>
+              </div>
+            </div>
+            <p className="text-sm text-slate-500">
+              Consider layering a subtle animated path from the opening scene to the venue to visualise the full journey.
+            </p>
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/InteractivitySection.tsx
+++ b/src/app/invitation/road-to-forever/components/InteractivitySection.tsx
@@ -1,0 +1,49 @@
+import { PageSection } from "@components/shared/PageSection";
+
+const interactions = [
+  {
+    action: "Scroll / Swipe Right",
+    effect: "The convertible advances to the next checkpoint with synced MotionPath progress.",
+  },
+  {
+    action: "Hover on Signboards",
+    effect: "Glow highlight and reveal mini pop-ups of Nara & Dimas' milestone memories.",
+  },
+  {
+    action: "Toggle Music",
+    effect: "Ambient road-trip soundtrack fades in/out using Howler.js for seamless loops.",
+  },
+  {
+    action: "Click RSVP",
+    effect: "Modal lifts with Framer Motion spring; submitting triggers celebratory confetti and pauses the car at the venue.",
+  },
+];
+
+export function InteractivitySection() {
+  return (
+    <PageSection
+      eyebrow="Interaction Map"
+      title="Driving the Experience"
+      className="border-slate-200/70 bg-gradient-to-br from-white via-slate-50 to-sky-50"
+    >
+      <p>
+        Road to Forever is designed as a horizontal journey where every action nudges the narrative forward. Use the map below to
+        coordinate micro-interactions with their respective animation cues.
+      </p>
+      <div className="mt-6 overflow-hidden rounded-3xl border border-slate-200 bg-white/80">
+        <div className="grid grid-cols-1 divide-y divide-slate-200 text-sm text-slate-600 md:grid-cols-2 md:divide-x md:divide-y-0">
+          {interactions.map((item) => (
+            <div key={item.action} className="p-5">
+              <p className="font-semibold uppercase tracking-[0.2em] text-slate-500">{item.action}</p>
+              <p className="mt-2 leading-relaxed">{item.effect}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <p className="text-sm text-slate-500">
+        Implement container-based ScrollTrigger timelines so each scene can be iterated independently without breaking the full
+        journey.
+      </p>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/MeetSceneSection.tsx
+++ b/src/app/invitation/road-to-forever/components/MeetSceneSection.tsx
@@ -1,0 +1,51 @@
+import { PageSection } from "@components/shared/PageSection";
+
+export function MeetSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 2"
+      title="Where Our Paths Crossed"
+      className="border-sky-200/60 bg-gradient-to-br from-white via-sky-50 to-emerald-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1fr_1fr] lg:items-center">
+        <div className="relative overflow-hidden rounded-3xl border border-sky-200 bg-white/80 p-8 shadow-inner">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_75%)]" />
+          <div className="relative space-y-4">
+            <p className="font-semibold uppercase tracking-[0.25em] text-sky-600">Parallax city</p>
+            <p className="text-slate-600">
+              Layered silhouettes of buildings, trees, and signage move at different speeds as the car glides across the road. A
+              playful signboard labelled “Our First Stop” glows subtly on hover.
+            </p>
+            <p className="text-slate-600">
+              Use GSAP timelines to coordinate the vehicle&apos;s MotionPath with typography fades and skyline parallax, evoking the
+              nostalgia of their first encounter.
+            </p>
+          </div>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl border border-sky-200 bg-white/90 p-4 text-sm">
+              <p className="font-semibold text-sky-600">Storyboard</p>
+              <p className="mt-1 text-slate-600">City panorama slides by while the camera gently pans with the car.</p>
+            </div>
+            <div className="rounded-2xl border border-emerald-200 bg-white/90 p-4 text-sm">
+              <p className="font-semibold text-emerald-600">Interaction</p>
+              <p className="mt-1 text-slate-600">Hover on the sign to trigger a glow and display a memory tooltip.</p>
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <p>
+            Colour the scene with warm blue hour tones that contrast the orange highlights of the hero section. Ambient audio of
+            distant city birds and soft wind adds texture without overpowering the soundtrack.
+          </p>
+          <p>
+            Suggested assets include vector skylines, illustrated foliage, and a custom type badge for the signpost. Optimise the
+            stack with `next/image` responsive imports to keep the horizontal journey performant.
+          </p>
+          <p className="rounded-2xl border border-sky-200/60 bg-white/70 p-4 text-sm text-slate-600">
+            Motion tip: anchor the vehicle to an invisible layer, then animate the environment instead of the car for smoother parallax on low-powered devices.
+          </p>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/MoodboardSection.tsx
+++ b/src/app/invitation/road-to-forever/components/MoodboardSection.tsx
@@ -1,0 +1,53 @@
+import { PageSection } from "@components/shared/PageSection";
+
+const palette = [
+  { name: "Pastel beige", value: "#f8ede3" },
+  { name: "Dusty orange", value: "#f5a261" },
+  { name: "Mint green", value: "#b6e2d3" },
+  { name: "Warm blue", value: "#74b9ff" },
+];
+
+export function MoodboardSection() {
+  return (
+    <PageSection
+      eyebrow="Moodboard"
+      title="Visual & Audio Direction"
+      className="border-slate-200/60 bg-gradient-to-br from-white via-slate-50 to-orange-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-4">
+          <p>
+            The mood blends cinematic nostalgia with playful optimism. Pair Montserrat for headings and Poppins for body copy to
+            keep typography crisp across both Indonesian and English copywriting.
+          </p>
+          <p>
+            Transition the lighting from morning blues to sunset ambers as the journey advances. An ambient road-trip soundtrack
+            with gentle percussions anchors the entire experience.
+          </p>
+          <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 text-sm text-slate-600">
+            <p className="font-semibold text-slate-700">Audio cues</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>Engine ignition &amp; soft wind during the opening scene.</li>
+              <li>City ambience layered with subtle guitar riffs for the meet scene.</li>
+              <li>Piano swells and ocean waves to underline the proposal moment.</li>
+            </ul>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {palette.map((color) => (
+              <div key={color.name} className="rounded-3xl border border-slate-200 bg-white/80 p-4">
+                <div className="h-24 rounded-2xl" style={{ backgroundColor: color.value }} />
+                <p className="mt-3 text-sm font-medium text-slate-700">{color.name}</p>
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">{color.value}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-sm text-slate-500">
+            Consider pairing the palette with grain overlays or halftone textures for extra warmth while keeping assets lightweight.
+          </p>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/OpeningSceneSection.tsx
+++ b/src/app/invitation/road-to-forever/components/OpeningSceneSection.tsx
@@ -1,0 +1,49 @@
+import { PageSection } from "@components/shared/PageSection";
+
+export function OpeningSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 1"
+      title="The Journey Begins"
+      className="border-orange-200/60 bg-gradient-to-br from-sky-50 via-white to-orange-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+        <div className="space-y-4">
+          <p>
+            Dawn breaks over a still road as Nara &amp; Dimas prepare for their first ride. Soft clouds drift across the hero panel
+            while the convertible waits on the left edge of the viewport, ready to follow the SVG highway.
+          </p>
+          <p>
+            The scene is pinned as the user begins to scroll. MotionPath animates the car forward while ScrollTrigger synchronises
+            the sunrise gradient and type reveal for the line “Every love story starts with a first ride.”
+          </p>
+          <ul className="grid gap-3 sm:grid-cols-2">
+            <li className="rounded-2xl border border-orange-200/60 bg-white/80 p-4 text-sm">
+              <p className="font-semibold text-orange-600">Visual beats</p>
+              <p className="mt-1 text-slate-600">Morning sky gradient, drifting clouds, hero quote fade-in.</p>
+            </li>
+            <li className="rounded-2xl border border-sky-200/60 bg-white/80 p-4 text-sm">
+              <p className="font-semibold text-sky-600">Technical notes</p>
+              <p className="mt-1 text-slate-600">Horizontal scroll container, pinned timeline, ambient engine audio.</p>
+            </li>
+          </ul>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border border-orange-100 bg-white/70 p-8 shadow-inner">
+          <div className="absolute inset-x-0 top-6 mx-auto h-28 w-28 rounded-full bg-gradient-to-br from-orange-200 via-amber-200 to-transparent blur-xl" />
+          <div className="relative h-32 rounded-full border border-slate-200 bg-gradient-to-r from-sky-100 via-white to-orange-100">
+            <div className="absolute inset-0 flex items-end justify-start px-6 pb-4">
+              <div className="flex h-12 items-center gap-3 rounded-full border border-orange-300/70 bg-orange-100 px-4 text-orange-700 shadow-md">
+                <span className="text-lg">🚗</span>
+                <span className="text-xs uppercase tracking-[0.25em]">Ignition</span>
+              </div>
+            </div>
+            <div className="absolute inset-x-6 bottom-3 h-1 rounded-full bg-gradient-to-r from-sky-300 via-orange-300 to-rose-200" />
+          </div>
+          <p className="mt-6 text-sm text-slate-500">
+            Tip: Layer the road, sky, and UI badges on different z-index levels to amplify parallax.
+          </p>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/ProposalSceneSection.tsx
+++ b/src/app/invitation/road-to-forever/components/ProposalSceneSection.tsx
@@ -1,0 +1,55 @@
+import { PageSection } from "@components/shared/PageSection";
+
+export function ProposalSceneSection() {
+  return (
+    <PageSection
+      eyebrow="Scene 4"
+      title="The Proposal Stop"
+      className="border-rose-200/60 bg-gradient-to-br from-orange-50 via-rose-50 to-slate-50"
+    >
+      <div className="grid gap-8 lg:grid-cols-[1.05fr_1fr] lg:items-center">
+        <div className="space-y-4">
+          <p>
+            The car eases to a halt beside a glowing horizon. Silhouettes of Nara &amp; Dimas appear next to the vehicle as confetti
+            sparkles fall from the sky. The camera momentarily locks, allowing the couple&apos;s quote “And at this stop, forever
+            began.” to breathe.
+          </p>
+          <p>
+            A GSAP fade sequence blends sunset gradients, confetti particles, and gentle zoom-out before the scene transitions
+            towards the wedding venue map.
+          </p>
+          <div className="rounded-3xl border border-rose-200/70 bg-white/80 p-6 text-sm text-slate-600">
+            <p className="font-semibold text-rose-600">Art direction</p>
+            <p className="mt-2">
+              Combine soft peach and magenta for the sky, layer silhouettes with multiply blend modes, and add a faint glassmorphism card for the quote.
+            </p>
+          </div>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border border-rose-200 bg-white/80 p-8 shadow-inner">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(248,113,113,0.16),_transparent_75%)]" />
+          <div className="relative space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="rounded-full border border-rose-300/70 bg-rose-100 px-4 py-2 text-xs uppercase tracking-[0.25em] text-rose-600">
+                Pause &amp; Promise
+              </div>
+              <div className="rounded-full border border-orange-300/70 bg-orange-100 px-4 py-2 text-xs uppercase tracking-[0.25em] text-orange-600">
+                Confetti FX
+              </div>
+            </div>
+            <div className="relative overflow-hidden rounded-[2.5rem] border border-rose-200 bg-gradient-to-br from-rose-50 via-white to-orange-50 p-6 shadow">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(251,191,36,0.25),_transparent_70%)]" />
+              <div className="relative space-y-3 text-center text-slate-600">
+                <p className="text-sm uppercase tracking-[0.35em] text-rose-500">Quote overlay</p>
+                <p className="font-display text-2xl text-slate-800">“And at this stop, forever began.”</p>
+                <p className="text-xs text-slate-500">Reveal after the vehicle brakes to zero velocity.</p>
+              </div>
+            </div>
+            <p className="text-sm text-slate-500">
+              Audio bed: soft piano with distant ocean waves fades in as the confetti descends.
+            </p>
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  );
+}

--- a/src/app/invitation/road-to-forever/components/RoadToForeverHero.tsx
+++ b/src/app/invitation/road-to-forever/components/RoadToForeverHero.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const carVariants = {
+  initial: { x: -40, opacity: 0 },
+  animate: { x: 0, opacity: 1 },
+};
+
+const sunVariants = {
+  initial: { scale: 0.8, opacity: 0 },
+  animate: { scale: 1, opacity: 1 },
+};
+
+export function RoadToForeverHero() {
+  return (
+    <div className="relative mx-auto max-w-5xl overflow-hidden rounded-[3rem] border border-orange-200/40 bg-gradient-to-b from-sky-100/70 via-white to-orange-50 px-10 pb-16 pt-20 text-slate-800 shadow-[0_40px_120px_-80px_rgba(15,23,42,0.55)]">
+      <div className="absolute inset-x-0 -top-40 h-72 bg-[radial-gradient(circle_at_center,_rgba(253,186,116,0.35),_transparent_70%)] blur-3xl" />
+      <div className="relative grid gap-12 lg:grid-cols-[1.35fr_1fr] lg:items-center">
+        <div className="space-y-6 text-left">
+          <motion.p
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="text-sm uppercase tracking-[0.3em] text-orange-500"
+          >
+            A cinematic road-trip invitation
+          </motion.p>
+          <motion.h1
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.2 }}
+            className="font-display text-4xl leading-tight text-slate-900 sm:text-5xl"
+          >
+            Road to Forever follows Nara &amp; Dimas through every mile that led to “I do”.
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.35 }}
+            className="max-w-xl text-lg text-slate-600"
+          >
+            Scroll horizontally to steer their vintage convertible across skylines, mountain passes, and the warm glow of their proposal.
+            Each checkpoint reveals immersive storytelling, layered parallax, and lovingly curated wedding details.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.5 }}
+            className="flex flex-wrap items-center gap-4 text-sm"
+          >
+            <div className="rounded-full border border-orange-300/50 bg-white/70 px-4 py-2 text-orange-600 backdrop-blur">Scroll to ignite the journey</div>
+            <div className="flex items-center gap-2 rounded-full border border-sky-300/60 bg-sky-50/80 px-4 py-2 text-sky-600 backdrop-blur">
+              <span className="h-2 w-2 rounded-full bg-sky-500 animate-ping" />
+              MotionPath storytelling
+            </div>
+          </motion.div>
+        </div>
+        <div className="relative mx-auto aspect-[3/4] w-full max-w-xs overflow-hidden rounded-[2.75rem] border border-orange-200/40 bg-gradient-to-b from-sky-100 via-white to-orange-50 shadow-[0_20px_60px_-40px_rgba(15,23,42,0.35)]">
+          <motion.div
+            variants={sunVariants}
+            initial="initial"
+            animate="animate"
+            transition={{ duration: 0.8, delay: 0.35, ease: [0.22, 1, 0.36, 1] }}
+            className="absolute -right-6 -top-6 h-32 w-32 rounded-full bg-gradient-to-br from-orange-200 via-orange-300 to-amber-300 blur-md"
+          />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.4),_transparent_70%)]" />
+          <div className="absolute inset-x-10 bottom-12 flex flex-col gap-4">
+            <div className="relative h-40 overflow-hidden rounded-full border border-slate-200 bg-white/70 shadow-inner">
+              <div className="absolute inset-0 bg-[linear-gradient(90deg,_rgba(56,189,248,0.15)_0%,_rgba(253,186,116,0.15)_100%)]" />
+              <motion.div
+                variants={carVariants}
+                initial="initial"
+                animate="animate"
+                transition={{ duration: 1.1, delay: 0.6, ease: [0.34, 1.56, 0.64, 1] }}
+                className="absolute bottom-6 left-6 flex items-center gap-3 rounded-full border border-orange-300/70 bg-orange-100 px-5 py-2 text-orange-700 shadow-md"
+              >
+                <span className="text-lg">🚗</span>
+                <span className="text-xs uppercase tracking-[0.3em]">Road to Forever</span>
+              </motion.div>
+              <div className="absolute bottom-4 left-0 right-0 h-2 bg-gradient-to-r from-sky-200 via-orange-200 to-rose-200 opacity-80" />
+            </div>
+            <p className="text-center text-xs uppercase tracking-[0.3em] text-slate-500">Interactive Scroll · Ambient Audio · RSVP Reveal</p>
+          </div>
+        </div>
+      </div>
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.7 }}
+        className="mt-16 flex items-center justify-center gap-3 text-sm text-slate-500"
+      >
+        <motion.span animate={{ x: [0, 6, 0] }} transition={{ repeat: Infinity, duration: 2, ease: "easeInOut" }}>
+          ↠
+        </motion.span>
+        Swipe or scroll right to join the drive
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/invitation/road-to-forever/gallery/page.tsx
+++ b/src/app/invitation/road-to-forever/gallery/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Road to Forever — Gallery",
+  description: "Placeholder gallery page for the Road to Forever invitation variant.",
+};
+
+export default function RoadToForeverGalleryPage() {
+  return (
+    <BaseInvitationLayout
+      theme="sunset-drive"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-slate-800">
+          <h1 className="font-display text-5xl">Gallery</h1>
+          <p className="mt-3 text-slate-500">
+            Curate cinemagraphs, cityscapes, and travel polaroids from Nara &amp; Dimas&apos; journey to enrich the Road to Forever experience.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-orange-200/60 bg-white/80">
+        <p>
+          Replace this placeholder once the creative assets, looping background videos, and interactive gallery hotspots are ready to be integrated.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/road-to-forever/gift/page.tsx
+++ b/src/app/invitation/road-to-forever/gift/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Road to Forever — Gift",
+  description: "Placeholder gift registry page for the Road to Forever invitation variant.",
+};
+
+export default function RoadToForeverGiftPage() {
+  return (
+    <BaseInvitationLayout
+      theme="sunset-drive"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-slate-800">
+          <h1 className="font-display text-5xl">Gift Registry</h1>
+          <p className="mt-3 text-slate-500">
+            Prepare space for curated registries, digital angpao, and personalised thank-you messages themed around the road-trip narrative.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-slate-200/60 bg-white/80">
+        <p>
+          Swap this placeholder with actual payment integrations, banking details, or charity links that suit Nara &amp; Dimas&apos; Road to Forever story.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/road-to-forever/page.tsx
+++ b/src/app/invitation/road-to-forever/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { invitationCatalog } from "@config/invitation";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { RoadToForeverHero } from "./components/RoadToForeverHero";
+import { OpeningSceneSection } from "./components/OpeningSceneSection";
+import { MeetSceneSection } from "./components/MeetSceneSection";
+import { AdventureSceneSection } from "./components/AdventureSceneSection";
+import { ProposalSceneSection } from "./components/ProposalSceneSection";
+import { DestinationSceneSection } from "./components/DestinationSceneSection";
+import { InteractivitySection } from "./components/InteractivitySection";
+import { MoodboardSection } from "./components/MoodboardSection";
+
+const invitation = invitationCatalog.presets.find((preset) => preset.slug === "road-to-forever");
+
+export const metadata: Metadata = {
+  title: "Road to Forever",
+  description:
+    "A horizontal-scroll wedding experience that drives guests through Nara & Dimas' cinematic milestones before arriving at their celebration.",
+};
+
+export default function RoadToForeverPage() {
+  if (!invitation) {
+    notFound();
+  }
+
+  return (
+    <BaseInvitationLayout
+      theme="sunset-drive"
+      hero={<RoadToForeverHero />}
+      footer={
+        <div className="space-y-2">
+          <p>Thank you for riding along Nara &amp; Dimas&apos; Road to Forever.</p>
+          <p className="text-xs text-orange-100/80">Crafted as part of the cinematic road-trip invitation series.</p>
+        </div>
+      }
+    >
+      <OpeningSceneSection />
+      <MeetSceneSection />
+      <AdventureSceneSection />
+      <ProposalSceneSection />
+      <DestinationSceneSection />
+      <InteractivitySection />
+      <MoodboardSection />
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/road-to-forever/rsvp/page.tsx
+++ b/src/app/invitation/road-to-forever/rsvp/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Road to Forever — RSVP",
+  description: "Placeholder RSVP page for the Road to Forever invitation variant.",
+};
+
+export default function RoadToForeverRsvpPage() {
+  return (
+    <BaseInvitationLayout
+      theme="sunset-drive"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-slate-800">
+          <h1 className="font-display text-5xl">RSVP</h1>
+          <p className="mt-3 text-slate-500">
+            Embed RSVP forms, guest passcodes, and seat selection with animations that match the horizontal road narrative.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Content" className="border-slate-200/60 bg-white/80">
+        <p>
+          Replace this placeholder with the production-ready RSVP flow. Coordinate success states with the finale confetti sequence and ensure timezone-aware schedule confirmations.
+        </p>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/app/invitation/road-to-forever/story/page.tsx
+++ b/src/app/invitation/road-to-forever/story/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from "next";
+import { BaseInvitationLayout } from "@components/layout/BaseInvitationLayout";
+import { PageSection } from "@components/shared/PageSection";
+
+export const metadata: Metadata = {
+  title: "Road to Forever — Story",
+  description: "Storyboard and narrative blueprint for the Road to Forever invitation variant.",
+};
+
+export default function RoadToForeverStoryPage() {
+  return (
+    <BaseInvitationLayout
+      theme="sunset-drive"
+      hero={
+        <div className="mx-auto max-w-3xl text-center text-slate-800">
+          <h1 className="font-display text-5xl">Storyboard</h1>
+          <p className="mt-3 text-slate-500">
+            Reference notes for crafting the cinematic horizontal journey of Nara &amp; Dimas.
+          </p>
+        </div>
+      }
+    >
+      <PageSection title="Scene Outline" className="border-orange-200/60 bg-white/80">
+        <ol className="list-decimal space-y-3 pl-5 text-slate-600">
+          <li>
+            <span className="font-medium text-slate-700">Opening Scene:</span> Sunrise, car ignition, gentle motion cue.
+          </li>
+          <li>
+            <span className="font-medium text-slate-700">Where We Met:</span> Parallax cityscape, glowing signboard, nostalgic copy.
+          </li>
+          <li>
+            <span className="font-medium text-slate-700">Our Adventures:</span> Mountainous roads, lighting shift, tilt effect.
+          </li>
+          <li>
+            <span className="font-medium text-slate-700">Proposal Stop:</span> Sunset pause, silhouette reveal, confetti fall.
+          </li>
+          <li>
+            <span className="font-medium text-slate-700">Wedding Destination:</span> Venue reveal, RSVP &amp; map call-to-actions.
+          </li>
+        </ol>
+      </PageSection>
+      <PageSection title="Production Notes" className="border-slate-200/60 bg-white/80">
+        <ul className="list-disc space-y-2 pl-5 text-slate-600">
+          <li>Adopt container-based ScrollTrigger to manage horizontal pinning.</li>
+          <li>Optimise SVG road assets and reuse across breakpoints.</li>
+          <li>Prepare audio stems for ignition, city ambience, adventure, proposal, and finale.</li>
+          <li>Design fallback states for non-horizontal scroll devices by stacking scenes vertically.</li>
+        </ul>
+      </PageSection>
+    </BaseInvitationLayout>
+  );
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -15,3 +15,9 @@
   --color-secondary: #10b981;
   --color-accent: #f59e0b;
 }
+
+[data-theme="sunset-drive"] {
+  --color-primary: #f97316;
+  --color-secondary: #38bdf8;
+  --color-accent: #fcd34d;
+}


### PR DESCRIPTION
## Summary
- add the Road to Forever invitation entry with bespoke hero and storyboard-driven sections inspired by the provided docs
- scaffold gallery, gift, rsvp, and story routes so the new variant mirrors the existing invitation structure
- register the sunset-drive theme palette and catalog metadata for the new preset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27be26bfc8322ac4377bee446d785